### PR TITLE
added browserAction and key command. removed new tab override

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,16 @@
+chrome.browserAction.onClicked.addListener(e => {
+  const url = chrome.runtime.getURL('index.html');
+  const queriedTab = chrome.tabs.query({'url': url}, tabList => {
+    if (tabList.length > 0) {
+      const tab = tabList[0];
+      chrome.tabs.update(tab.id, {
+        'active': true
+      });
+    } else {
+      chrome.tabs.create({
+        'url': url,
+        'active': true
+      });
+    }
+  });
+});

--- a/index.js
+++ b/index.js
@@ -84,6 +84,8 @@ const init = () => {
   editorElement = document.querySelector('#c');
   errorElement = document.querySelector("#error");
   
+  editorElement.focus();
+  
   // mock chrome.storage.sync to work with localStorage if not embedded in chrome extension
   if (!chrome.storage) {
     chrome.storage = {

--- a/manifest.json
+++ b/manifest.json
@@ -8,15 +8,15 @@
       "persistent": false
     },
     "browser_action": {
-      "default_title": "BlinkNote - Ctrl+N"
+      "default_title": "BlinkNote - Alt+B"
     },
     "commands": {
       "_execute_browser_action": {
         "suggested_key": {
-          "default": "Ctrl+N",
-          "mac": "MacCtrl+N"
+          "default": "Alt+B",
+          "mac": "Alt+B"
         },
-        "description": "BlinkNote - MacCtrl+N / Ctrl+N"
+        "description": "BlinkNote - Alt+B"
       }
     },
     "manifest_version": 2

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,23 @@
   {
     "name": "BlinkNote",
     "version": "1.0",
-    "description": "fastest way to take a note that'll stick around",
-    "permissions": ["storage"],
-    "chrome_url_overrides" : {
-      "newtab": "index.html"
+    "description": "Fastest way to take a note that'll stick around",
+    "permissions": ["storage", "tabs"],
+    "background": {
+      "scripts": ["background.js"],
+      "persistent": false
+    },
+    "browser_action": {
+      "default_title": "BlinkNote - Ctrl+N"
+    },
+    "commands": {
+      "_execute_browser_action": {
+        "suggested_key": {
+          "default": "Ctrl+N",
+          "mac": "MacCtrl+N"
+        },
+        "description": "BlinkNote - MacCtrl+N / Ctrl+N"
+      }
     },
     "manifest_version": 2
   }


### PR DESCRIPTION
This removes the new tab override, and introduces a browser button and key command to open the editor. I chose `Ctrl+N` for the key command but open to other options. Still need to do an icon.